### PR TITLE
feat: handle vertex, edge and path datatype in JDBC driver

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,0 +1,15 @@
+# Default build parameters.  These may be overridden by local configuration
+# settings in build.local.properties.
+#
+
+server=localhost
+port=5432
+database=test
+username=postgres
+password=test
+privilegedUser=postgres
+privilegedPassword=
+sspiusername=testsspi
+preparethreshold=5
+loglevel=0
+protocolVersion=0

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@ limitations under the License.
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>kr.co.bitnine.agens-graph</groupId>
-  <artifactId>agens-graph-jdbc</artifactId>
+  <groupId>net.bitnine.agensgraph</groupId>
+  <artifactId>agensgraph-jdbc</artifactId>
   <version>0.1.0-SNAPSHOT</version>
 
   <name>Agens Graph JDBC</name>
@@ -28,7 +28,13 @@ limitations under the License.
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>9.4-1201-jdbc41</version>
+      <version>9.4.1208.jre7</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/net/bitnine/agensgraph/AgensGraphConnection.java
+++ b/src/main/java/net/bitnine/agensgraph/AgensGraphConnection.java
@@ -14,20 +14,20 @@
 
 package net.bitnine.agensgraph;
 
-import org.postgresql.jdbc4.Jdbc4Connection;
+import org.postgresql.jdbc.PgConnection;
 import org.postgresql.util.HostSpec;
 
 import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import java.util.Properties;
 
-class AgensGraphConnection extends Jdbc4Connection {
+class AgensGraphConnection extends PgConnection {
     AgensGraphConnection(HostSpec[] hostSpecs, String user, String database, Properties info, String url) throws SQLException {
         super(hostSpecs, user, database, info, url);
     }
 
     /*
-     * We override getMetaData() to return AgensGraphOctopusDatabaseMetaData.
+     * We override getMetaData() to return AgensGraphDatabaseMetaData.
      * This is the main reason why we made this class.
      */
     @Override
@@ -35,7 +35,7 @@ class AgensGraphConnection extends Jdbc4Connection {
         checkClosed();
 
         if (metadata == null)
-            metadata = new AgensGraphOctopusDatabaseMetaData(this);
+            metadata = new AgensGraphDatabaseMetaData(this);
 
         return metadata;
     }

--- a/src/main/java/net/bitnine/agensgraph/AgensGraphDatabaseMetaData.java
+++ b/src/main/java/net/bitnine/agensgraph/AgensGraphDatabaseMetaData.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.bitnine.agensgraph;
+
+import org.postgresql.jdbc.PgConnection;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+
+class AgensGraphDatabaseMetaData extends AbstractDatabaseMetaData {
+    private final Connection connection;
+
+    AgensGraphDatabaseMetaData(PgConnection conn) {
+        this.connection = conn;
+    }
+
+    @Override
+    public ResultSet getTables(String catalog, String schemaPattern, String tableNamePattern, String[] types) throws SQLException {
+        Statement stmt = createMetaDataStatement();
+
+        String sql = "SHOW TABLES";
+        if (catalog != null)
+            sql += " DATASOURCE \"" + catalog + '"';
+        if (schemaPattern != null)
+            sql += " SCHEMA '" + schemaPattern + "'";
+        if (tableNamePattern != null)
+            sql += " TABLE '" + tableNamePattern + "'";
+
+        return stmt.executeQuery(sql);
+    }
+
+    @Override
+    public ResultSet getSchemas() throws SQLException {
+        return createMetaDataStatement().executeQuery("SHOW SCHEMAS");
+    }
+
+    @Override
+    public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
+        Statement stmt = createMetaDataStatement();
+
+        String sql = "SHOW SCHEMAS";
+        if (catalog != null)
+            sql += " DATASOURCE \"" + catalog + '"';
+        if (schemaPattern != null)
+            sql += " SCHEMA '" + schemaPattern + "'";
+
+        return stmt.executeQuery(sql);
+    }
+
+    @Override
+    public ResultSet getCatalogs() throws SQLException {
+        return createMetaDataStatement().executeQuery("SHOW DATASOURCES");
+    }
+
+    @Override
+    public ResultSet getColumns(String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern) throws SQLException {
+        Statement stmt = createMetaDataStatement();
+
+        String sql = "SHOW COLUMNS";
+        if (catalog != null)
+            sql += " DATASOURCE \"" + catalog + '"';
+        if (schemaPattern != null)
+            sql += " SCHEMA '" + schemaPattern + "'";
+        if (tableNamePattern != null)
+            sql += " TABLE '" + tableNamePattern + "'";
+        if (columnNamePattern != null)
+            sql += " COLUMN '" + columnNamePattern + "'";
+
+        return stmt.executeQuery(sql);
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return connection;
+    }
+
+    private Statement createMetaDataStatement() throws SQLException {
+        return getConnection().createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE, ResultSet.CONCUR_READ_ONLY);
+    }
+}

--- a/src/main/java/net/bitnine/agensgraph/Driver.java
+++ b/src/main/java/net/bitnine/agensgraph/Driver.java
@@ -20,6 +20,7 @@ package net.bitnine.agensgraph;
 
 import org.postgresql.PGProperty;
 import org.postgresql.core.Logger;
+import org.postgresql.jdbc.PgConnection;
 import org.postgresql.util.GT;
 import org.postgresql.util.HostSpec;
 import org.postgresql.util.PSQLException;
@@ -29,7 +30,7 @@ import org.postgresql.util.SharedTimer;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.security.AccessControlException;
+import java.net.URLDecoder;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
@@ -43,34 +44,37 @@ import java.util.Enumeration;
 import java.util.Properties;
 
 /**
- * The Java SQL framework allows for multiple database drivers.  Each
- * driver should supply a class that implements the Driver interface
- * <p/>
- * <p>The DriverManager will try to load as many drivers as it can find and
- * then for any given connection request, it will ask each driver in turn
- * to try to connect to the target URL.
- * <p/>
- * <p>It is strongly recommended that each Driver class should be small and
- * standalone so that the Driver class can be loaded and queried without
- * bringing in vast quantities of supporting code.
- * <p/>
- * <p>When a Driver class is loaded, it should create an instance of itself
- * and register it with the DriverManager. This means that a user can load
- * and register a driver by doing Class.forName("foo.bah.Driver")
+ * The Java SQL framework allows for multiple database drivers. Each driver should supply a class
+ * that implements the Driver interface
+ *
+ * <p>
+ * The DriverManager will try to load as many drivers as it can find and then for any given
+ * connection request, it will ask each driver in turn to try to connect to the target URL.
+ *
+ * <p>
+ * It is strongly recommended that each Driver class should be small and standalone so that the
+ * Driver class can be loaded and queried without bringing in vast quantities of supporting code.
+ *
+ * <p>
+ * When a Driver class is loaded, it should create an instance of itself and register it with the
+ * DriverManager. This means that a user can load and register a driver by doing
+ * Class.forName("foo.bah.Driver")
  *
  * @see org.postgresql.PGConnection
  * @see java.sql.Driver
  */
-public final class Driver implements java.sql.Driver {
+public class Driver implements java.sql.Driver {
+
     // make these public so they can be used in setLogLevel below
+
     public static final int DEBUG = 2;
     public static final int INFO = 1;
     public static final int OFF = 0;
 
     private static Driver registeredDriver;
-    private static final Logger LOGGER = new Logger();
-    private static boolean logLevelSet;
-    private static SharedTimer sharedTimer = new SharedTimer(LOGGER);
+    private static final Logger logger = new Logger();
+    private static boolean logLevelSet = false;
+    private static SharedTimer sharedTimer = new SharedTimer(logger);
 
     static {
         try {
@@ -89,15 +93,16 @@ public final class Driver implements java.sql.Driver {
     private Properties defaultProperties;
 
     private synchronized Properties getDefaultProperties() throws IOException {
-        if (defaultProperties != null)
+        if (defaultProperties != null) {
             return defaultProperties;
+        }
 
         // Make sure we load properties with the maximum possible
         // privileges.
         try {
-            defaultProperties = (Properties) AccessController.doPrivileged(
-                    new PrivilegedExceptionAction() {
-                        public Object run() throws IOException {
+            defaultProperties =
+                    AccessController.doPrivileged(new PrivilegedExceptionAction<Properties>() {
+                        public Properties run() throws IOException {
                             return loadDefaultProperties();
                         }
                     });
@@ -114,7 +119,8 @@ public final class Driver implements java.sql.Driver {
                 if (driverLogLevel != null) {
                     try {
                         setLogLevel(Integer.parseInt(driverLogLevel));
-                    } catch (Exception ignore) {
+                    } catch (Exception l_e) {
+                        // XXX revisit
                         // invalid value for loglevel; ignore it
                     }
                 }
@@ -143,28 +149,34 @@ public final class Driver implements java.sql.Driver {
         // when our classloader is null. The ClassLoader javadoc claims
         // neither case can throw SecurityException.
         ClassLoader cl = getClass().getClassLoader();
-        if (cl == null)
+        if (cl == null) {
             cl = ClassLoader.getSystemClassLoader();
+        }
 
         if (cl == null) {
-            LOGGER.debug("Can't find a classloader for the Driver; not loading driver configuration");
+            logger.debug("Can't find a classloader for the Driver; not loading driver configuration");
             return merged; // Give up on finding defaults.
         }
 
-        LOGGER.debug("Loading driver configuration via classloader " + cl);
+        if (logger.logDebug()) {
+            logger.debug("Loading driver configuration via classloader " + cl);
+        }
 
         // When loading the driver config files we don't want settings found
         // in later files in the classpath to override settings specified in
-        // earlier files.  To do this we've got to read the returned
+        // earlier files. To do this we've got to read the returned
         // Enumeration into temporary storage.
-        ArrayList<URL> urls = new ArrayList();
+        ArrayList<URL> urls = new ArrayList<URL>();
         Enumeration<URL> urlEnum = cl.getResources("org/postgresql/driverconfig.properties");
-        while (urlEnum.hasMoreElements())
+        while (urlEnum.hasMoreElements()) {
             urls.add(urlEnum.nextElement());
+        }
 
         for (int i = urls.size() - 1; i >= 0; i--) {
             URL url = urls.get(i);
-            LOGGER.debug("Loading driver configuration from: " + url);
+            if (logger.logDebug()) {
+                logger.debug("Loading driver configuration from: " + url);
+            }
             InputStream is = url.openStream();
             merged.load(is);
             is.close();
@@ -174,59 +186,49 @@ public final class Driver implements java.sql.Driver {
     }
 
     /**
-     * Try to make a database connection to the given URL. The driver
-     * should return "null" if it realizes it is the wrong kind of
-     * driver to connect to the given URL. This will be common, as
-     * when the JDBC driverManager is asked to connect to a given URL,
-     * it passes the URL to each loaded driver in turn.
-     * <p/>
-     * <p>The driver should raise an SQLException if it is the right driver
-     * to connect to the given URL, but has trouble connecting to the
-     * database.
-     * <p/>
-     * <p>The java.util.Properties argument can be used to pass arbitrary
-     * string tag/value pairs as connection arguments.
-     * <p/>
-     * user - (required) The user to connect as
-     * password - (optional) The password for the user
-     * ssl - (optional) Use SSL when connecting to the server
-     * readOnly - (optional) Set connection to read-only by default
-     * charSet - (optional) The character set to be used for converting
-     * to/from the database to unicode.  If multibyte is enabled on the
-     * server then the character set of the database is used as the default,
-     * otherwise the jvm character encoding is used as the default.
-     * This value is only used when connecting to a 7.2 or older server.
-     * loglevel - (optional) Enable logging of messages from the driver.
-     * The value is an integer from 0 to 2 where:
-     * OFF = 0, INFO = 1, DEBUG = 2
-     * The output is sent to DriverManager.getPrintWriter() if set,
-     * otherwise it is sent to System.out.
-     * compatible - (optional) This is used to toggle
-     * between different functionality as it changes across different releases
-     * of the jdbc driver code.  The values here are versions of the jdbc
-     * client and not server versions.  For example in 7.1 get/setBytes
-     * worked on LargeObject values, in 7.2 these methods were changed
-     * to work on bytea values.  This change in functionality could
-     * be disabled by setting the compatible level to be "7.1", in
-     * which case the driver will revert to the 7.1 functionality.
-     * <p/>
-     * <p>Normally, at least
-     * "user" and "password" properties should be included in the
-     * properties. For a list of supported
-     * character encoding , see
-     * http://java.sun.com/products/jdk/1.2/docs/guide/internat/encoding.doc.html
-     * Note that you will probably want to have set up the Postgres database
-     * itself to use the same encoding, with the "-E <encoding>" argument
-     * to createdb.
-     * <p/>
+     * Try to make a database connection to the given URL. The driver should return "null" if it
+     * realizes it is the wrong kind of driver to connect to the given URL. This will be common, as
+     * when the JDBC driverManager is asked to connect to a given URL, it passes the URL to each
+     * loaded driver in turn.
+     *
+     * <p>
+     * The driver should raise an SQLException if it is the right driver to connect to the given URL,
+     * but has trouble connecting to the database.
+     *
+     * <p>
+     * The java.util.Properties argument can be used to pass arbitrary string tag/value pairs as
+     * connection arguments.
+     *
+     * user - (required) The user to connect as password - (optional) The password for the user ssl -
+     * (optional) Use SSL when connecting to the server readOnly - (optional) Set connection to
+     * read-only by default charSet - (optional) The character set to be used for converting to/from
+     * the database to unicode. If multibyte is enabled on the server then the character set of the
+     * database is used as the default, otherwise the jvm character encoding is used as the default.
+     * This value is only used when connecting to a 7.2 or older server. loglevel - (optional) Enable
+     * logging of messages from the driver. The value is an integer from 0 to 2 where: OFF = 0, INFO =
+     * 1, DEBUG = 2 The output is sent to DriverManager.getPrintWriter() if set, otherwise it is sent
+     * to System.out. compatible - (optional) This is used to toggle between different functionality
+     * as it changes across different releases of the jdbc driver code. The values here are versions
+     * of the jdbc client and not server versions. For example in 7.1 get/setBytes worked on
+     * LargeObject values, in 7.2 these methods were changed to work on bytea values. This change in
+     * functionality could be disabled by setting the compatible level to be "7.1", in which case the
+     * driver will revert to the 7.1 functionality.
+     *
+     * <p>
+     * Normally, at least "user" and "password" properties should be included in the properties. For a
+     * list of supported character encoding , see
+     * http://java.sun.com/products/jdk/1.2/docs/guide/internat/encoding.doc.html Note that you will
+     * probably want to have set up the Postgres database itself to use the same encoding, with the
+     * {@code -E <encoding>} argument to createdb.
+     *
      * Our protocol takes the forms:
+     *
      * <PRE>
-     * jdbc:agensgraph://host:port/database?param1=val1&...
+     *  jdbc:agensgraph://host:port/database?param1=val1&amp;...
      * </PRE>
      *
-     * @param url  the URL of the database to connect to
-     * @param info a list of arbitrary tag/value pairs as connection
-     *             arguments
+     * @param url the URL of the database to connect to
+     * @param info a list of arbitrary tag/value pairs as connection arguments
      * @return a connection to the URL or null if it isnt us
      * @throws SQLException if a database access error occurs
      * @see java.sql.Driver#connect
@@ -235,9 +237,9 @@ public final class Driver implements java.sql.Driver {
         // get defaults
         Properties defaults;
 
-        if (!url.startsWith(AGENSGRAPH_PROTOCOL))
+        if (!url.startsWith("jdbc:agensgraph:")) {
             return null;
-
+        }
         try {
             defaults = getDefaultProperties();
         } catch (IOException ioe) {
@@ -248,25 +250,32 @@ public final class Driver implements java.sql.Driver {
         // override defaults with provided properties
         Properties props = new Properties(defaults);
         if (info != null) {
-            Enumeration e = info.propertyNames();
+            Enumeration<?> e = info.propertyNames();
             while (e.hasMoreElements()) {
                 String propName = (String) e.nextElement();
                 String propValue = info.getProperty(propName);
                 if (propValue == null) {
-                    throw new PSQLException(GT.tr("Properties for the driver contains a non-string value for the key ") + propName,
+                    throw new PSQLException(
+                            GT.tr("Properties for the driver contains a non-string value for the key ")
+                                    + propName,
                             PSQLState.UNEXPECTED_ERROR);
                 }
                 props.setProperty(propName, propValue);
             }
         }
         // parse URL and add more properties
-        props = parseURL(url, props);
-        if (props == null) {
-            LOGGER.debug("Error in url: " + url);
+        if ((props = parseURL(url, props)) == null) {
+            logger.debug("Error in url: " + url);
             return null;
         }
+        // add properties for additional datatypes in Agens Graph
+        props.setProperty("datatype.vertex", "net.bitnine.agensgraph.graph.Vertex");
+        props.setProperty("datatype.edge", "net.bitnine.agensgraph.graph.Edge");
+        props.setProperty("datatype.path", "net.bitnine.agensgraph.graph.Path");
         try {
-            LOGGER.debug("Connecting with URL: " + url);
+            if (logger.logDebug()) {
+                logger.debug("Connecting with URL: " + url);
+            }
 
             // Enforce login timeout, if specified, by running the connection
             // attempt in a separate thread. If we hit the timeout without the
@@ -277,32 +286,37 @@ public final class Driver implements java.sql.Driver {
             // we managed to establish one after all. See ConnectThread for
             // more details.
             long timeout = timeout(props);
-            if (timeout <= 0)
+            if (timeout <= 0) {
                 return makeConnection(url, props);
+            }
 
             ConnectThread ct = new ConnectThread(url, props);
-            Thread thread = new Thread(ct, "Agens Graph JDBC driver connection thread");
+            Thread thread = new Thread(ct, "AgensGraph JDBC driver connection thread");
             thread.setDaemon(true); // Don't prevent the VM from shutting down
             thread.start();
             return ct.getResult(timeout);
         } catch (PSQLException ex1) {
-            LOGGER.debug("Connection error:", ex1);
+            logger.debug("Connection error:", ex1);
             // re-throw the exception, otherwise it will be caught next, and a
-            // org.postgresql.unusual error will be returned instead. // FIXME
+            // org.postgresql.unusual error will be returned instead.
             throw ex1;
-        } catch (AccessControlException ace) {
-            throw new PSQLException(GT.tr("Your security policy has prevented the connection from being attempted.  You probably need to grant the connect java.net.SocketPermission to the database server host and port that you wish to connect to."), PSQLState.UNEXPECTED_ERROR, ace);
+        } catch (java.security.AccessControlException ace) {
+            throw new PSQLException(
+                    GT.tr(
+                            "Your security policy has prevented the connection from being attempted.  You probably need to grant the connect java.net.SocketPermission to the database server host and port that you wish to connect to."),
+                    PSQLState.UNEXPECTED_ERROR, ace);
         } catch (Exception ex2) {
-            LOGGER.debug("Unexpected connection error:", ex2);
-            throw new PSQLException(GT.tr("Something unusual has occurred to cause the driver to fail. Please report this exception."),
+            logger.debug("Unexpected connection error:", ex2);
+            throw new PSQLException(
+                    GT.tr(
+                            "Something unusual has occurred to cause the driver to fail. Please report this exception."),
                     PSQLState.UNEXPECTED_ERROR, ex2);
         }
     }
 
     /**
-     * Perform a connect in a separate thread; supports
-     * getting the results from the original thread while enforcing
-     * a login timeout.
+     * Perform a connect in a separate thread; supports getting the results from the original thread
+     * while enforcing a login timeout.
      */
     private static class ConnectThread implements Runnable {
         ConnectThread(String url, Properties props) {
@@ -327,7 +341,8 @@ public final class Driver implements java.sql.Driver {
                     if (conn != null) {
                         try {
                             conn.close();
-                        } catch (SQLException ignored) { }
+                        } catch (SQLException e) {
+                        }
                     }
                 } else {
                     result = conn;
@@ -338,9 +353,8 @@ public final class Driver implements java.sql.Driver {
         }
 
         /**
-         * Get the connection result from this (assumed running) thread.
-         * If the timeout is reached without a result being available,
-         * a SQLException is thrown.
+         * Get the connection result from this (assumed running) thread. If the timeout is reached
+         * without a result being available, a SQLException is thrown.
          *
          * @param timeout timeout in milliseconds
          * @return the new connection, if successful
@@ -350,15 +364,18 @@ public final class Driver implements java.sql.Driver {
             long expiry = System.currentTimeMillis() + timeout;
             synchronized (this) {
                 while (true) {
-                    if (result != null)
+                    if (result != null) {
                         return result;
+                    }
 
                     if (resultException != null) {
                         if (resultException instanceof SQLException) {
                             resultException.fillInStackTrace();
                             throw (SQLException) resultException;
                         } else {
-                            throw new PSQLException(GT.tr("Something unusual has occurred to cause the driver to fail. Please report this exception."),
+                            throw new PSQLException(
+                                    GT.tr(
+                                            "Something unusual has occurred to cause the driver to fail. Please report this exception."),
                                     PSQLState.UNEXPECTED_ERROR, resultException);
                         }
                     }
@@ -373,6 +390,7 @@ public final class Driver implements java.sql.Driver {
                     try {
                         wait(delay);
                     } catch (InterruptedException ie) {
+
                         // reset the interrupt flag
                         Thread.currentThread().interrupt();
                         abandoned = true;
@@ -392,66 +410,66 @@ public final class Driver implements java.sql.Driver {
     }
 
     /**
-     * Create a connection from URL and properties. Always
-     * does the connection work in the current thread without
-     * enforcing a timeout, regardless of any timeout specified
-     * in the properties.
+     * Create a connection from URL and properties. Always does the connection work in the current
+     * thread without enforcing a timeout, regardless of any timeout specified in the properties.
      *
-     * @param url   the original URL
+     * @param url the original URL
      * @param props the parsed/defaulted connection properties
      * @return a new connection
      * @throws SQLException if the connection could not be made
      */
     private static Connection makeConnection(String url, Properties props) throws SQLException {
-        return new AgensGraphConnection(hostSpecs(props), user(props), database(props), props, url);
+        return new PgConnection(hostSpecs(props), user(props), database(props), props, url);
     }
 
     /**
-     * Returns true if the driver thinks it can open a connection to the
-     * given URL.  Typically, drivers will return true if they understand
-     * the subprotocol specified in the URL and false if they don't.  Our
-     * protocols start with jdbc:postgresql:
+     * Returns true if the driver thinks it can open a connection to the given URL. Typically, drivers
+     * will return true if they understand the subprotocol specified in the URL and false if they
+     * don't. Our protocols start with jdbc:postgresql:
      *
      * @param url the URL of the driver
      * @return true if this driver accepts the given URL
      * @see java.sql.Driver#acceptsURL
      */
     public boolean acceptsURL(String url) {
-        return parseURL(url, null) != null;
+        if (parseURL(url, null) == null) {
+            return false;
+        }
+        return true;
     }
 
     /**
-     * The getPropertyInfo method is intended to allow a generic GUI
-     * tool to discover what properties it should prompt a human for
-     * in order to get enough information to connect to a database.
-     * <p/>
-     * <p>Note that depending on the values the human has supplied so
-     * far, additional values may become necessary, so it may be necessary
-     * to iterate through several calls to getPropertyInfo
+     * The getPropertyInfo method is intended to allow a generic GUI tool to discover what properties
+     * it should prompt a human for in order to get enough information to connect to a database.
      *
-     * @param url  the Url of the database to connect to
-     * @param info a proposed list of tag/value pairs that will be sent on
-     *             connect open.
-     * @return An array of DriverPropertyInfo objects describing
-     * possible properties.  This array may be an empty array if
-     * no properties are required
+     * <p>
+     * Note that depending on the values the human has supplied so far, additional values may become
+     * necessary, so it may be necessary to iterate through several calls to getPropertyInfo
+     *
+     * @param url the Url of the database to connect to
+     * @param info a proposed list of tag/value pairs that will be sent on connect open.
+     * @return An array of DriverPropertyInfo objects describing possible properties. This array may
+     *         be an empty array if no properties are required
      * @see java.sql.Driver#getPropertyInfo
      */
     public DriverPropertyInfo[] getPropertyInfo(String url, Properties info) {
         Properties copy = new Properties(info);
         Properties parse = parseURL(url, copy);
-        if (parse != null)
+        if (parse != null) {
             copy = parse;
+        }
 
         PGProperty[] knownProperties = PGProperty.values();
         DriverPropertyInfo[] props = new DriverPropertyInfo[knownProperties.length];
-        for (int i = 0; i < props.length; ++i)
+        for (int i = 0; i < props.length; ++i) {
             props[i] = knownProperties[i].toDriverPropertyInfo(copy);
+        }
 
         return props;
     }
 
-    public static final int MAJORVERSION = 0; // must be same as Agens Graph major version
+    public static final int MAJORVERSION =
+      /*$mvn.project.property.parsedversion.majorversion+";"$*//*-*/9;
 
     /**
      * Gets the drivers major version number
@@ -462,8 +480,8 @@ public final class Driver implements java.sql.Driver {
         return MAJORVERSION;
     }
 
-
-    public static final int MINORVERSION = 1; // must be same as Agens Graph minor version
+    public static final int MINORVERSION =
+      /*$mvn.project.property.parsedversion.minorversion+";"$*//*-*/4;
 
     /**
      * Get the drivers minor version number
@@ -475,120 +493,104 @@ public final class Driver implements java.sql.Driver {
     }
 
     /**
-     * Returns the server version series of this driver and the
-     * specific build number.
+     * Returns the server version series of this driver and the specific build number.
+     *
+     * @return JDBC driver version
      */
     public static String getVersion() {
-        return "Agens Graph " + MAJORVERSION + "." + MINORVERSION + "JDBC4.1";
+        return "AgensGraph /*$mvn.project.property.parsedversion.osgiversion$*/";
     }
 
     /**
-     * Report whether the driver is a genuine JDBC compliant driver.  A
-     * driver may only report "true" here if it passes the JDBC compliance
-     * tests, otherwise it is required to return false.  JDBC compliance
-     * requires full support for the JDBC API and full support for SQL 92
-     * Entry Level.
-     * <p/>
-     * <p>For PostgreSQL, this is not yet possible, as we are not SQL92
-     * compliant (yet).
+     * Report whether the driver is a genuine JDBC compliant driver. A driver may only report "true"
+     * here if it passes the JDBC compliance tests, otherwise it is required to return false. JDBC
+     * compliance requires full support for the JDBC API and full support for SQL 92 Entry Level.
+     *
+     * <p>
+     * For PostgreSQL, this is not yet possible, as we are not SQL92 compliant (yet).
      */
     public boolean jdbcCompliant() {
         return false;
     }
 
-    private static final String[] PROTOCOLS = {"jdbc", "agensgraph"};
-    private static final String AGENSGRAPH_PROTOCOL = String.format("%s:%s:", (Object[]) PROTOCOLS);
-
-    private static final String DEFAULT_AGENSGRAPH_PORT = "58000";
-
     /**
-     * Constructs a new DriverURL, splitting the specified URL into its
-     * component parts
+     * Constructs a new DriverURL, splitting the specified URL into its component parts
      *
-     * @param url      JDBC URL to parse
+     * @param url JDBC URL to parse
      * @param defaults Default properties
      * @return Properties with elements added from the url
      */
     public static Properties parseURL(String url, Properties defaults) {
         Properties urlProps = new Properties(defaults);
 
-        String urlServer = url;
-        String urlArgs = "";
+        String l_urlServer = url;
+        String l_urlArgs = "";
 
-        int qPos = url.indexOf('?');
-        if (qPos != -1) {
-            urlServer = url.substring(0, qPos);
-            urlArgs = url.substring(qPos + 1);
+        int l_qPos = url.indexOf('?');
+        if (l_qPos != -1) {
+            l_urlServer = url.substring(0, l_qPos);
+            l_urlArgs = url.substring(l_qPos + 1);
         }
 
-        if (!urlServer.startsWith(AGENSGRAPH_PROTOCOL))
+        if (!l_urlServer.startsWith("jdbc:agensgraph:")) {
             return null;
+        }
+        l_urlServer = l_urlServer.substring("jdbc:agensgraph:".length());
 
-        urlServer = urlServer.substring(AGENSGRAPH_PROTOCOL.length());
+        if (l_urlServer.startsWith("//")) {
+            l_urlServer = l_urlServer.substring(2);
+            int slash = l_urlServer.indexOf('/');
+            if (slash == -1) {
+                return null;
+            }
+            urlProps.setProperty("PGDBNAME", URLDecoder.decode(l_urlServer.substring(slash + 1)));
 
-        if (urlServer.startsWith("//")) { // FIXME: Environment variables
-            urlServer = urlServer.substring(2);
-            int slashIdx = urlServer.indexOf('/');
-            if (slashIdx > -1)
-                urlServer = urlServer.substring(0, slashIdx);
-
+            String[] addresses = l_urlServer.substring(0, slash).split(",");
             StringBuilder hosts = new StringBuilder();
             StringBuilder ports = new StringBuilder();
-            String[] addrs = urlServer.split(",");
-            for (String addr : addrs) {
-                addr = addr.trim();
+            for (int addr = 0; addr < addresses.length; ++addr) {
+                String address = addresses[addr];
 
-                String host;
-                String port;
-
-                int portIdx = addr.lastIndexOf(':');
-                if (portIdx > -1 && addr.lastIndexOf(']') < portIdx) {
-                    host = addr.substring(0, portIdx);
-                    port = addr.substring(portIdx + 1);
-                    if (port.isEmpty()) {
-                        port = DEFAULT_AGENSGRAPH_PORT;
-                    } else {
-                        try {
-                            Integer.parseInt(port);
-                        } catch (NumberFormatException e) {
-                            return null;
-                        }
+                int portIdx = address.lastIndexOf(':');
+                if (portIdx != -1 && address.lastIndexOf(']') < portIdx) {
+                    String portStr = address.substring(portIdx + 1);
+                    try {
+                        Integer.parseInt(portStr);
+                    } catch (NumberFormatException ex) {
+                        return null;
                     }
+                    ports.append(portStr);
+                    hosts.append(address.subSequence(0, portIdx));
                 } else {
-                    host = addr;
-                    port = DEFAULT_AGENSGRAPH_PORT;
+                    ports.append("/*$mvn.project.property.template.default.pg.port$*/");
+                    hosts.append(address);
                 }
-
-                if (host.isEmpty())
-                    host = "localhost";
-
-                hosts.append(host).append(',');
-                ports.append(port).append(',');
+                ports.append(',');
+                hosts.append(',');
             }
-
+            ports.setLength(ports.length() - 1);
             hosts.setLength(hosts.length() - 1);
-            ports.setLength(hosts.length() - 1);
-
-            urlProps.setProperty("PGHOST", hosts.toString());
             urlProps.setProperty("PGPORT", ports.toString());
-            urlProps.setProperty("PGDBNAME", "<unknown>");
+            urlProps.setProperty("PGHOST", hosts.toString());
         } else {
+            urlProps.setProperty("PGPORT", "/*$mvn.project.property.template.default.pg.port$*/");
             urlProps.setProperty("PGHOST", "localhost");
-            urlProps.setProperty("PGPORT", DEFAULT_AGENSGRAPH_PORT);
-            urlProps.setProperty("PGDBNAME", "<unknown>");
+            urlProps.setProperty("PGDBNAME", URLDecoder.decode(l_urlServer));
         }
 
         // parse the args part of the url
-        String[] args = urlArgs.split("&");
-        for (String token : args) {
-            if (token.isEmpty())
+        String[] args = l_urlArgs.split("&");
+        for (int i = 0; i < args.length; ++i) {
+            String token = args[i];
+            if (token.length() == 0) {
                 continue;
-
-            int pos = token.indexOf('=');
-            if (pos > -1)
-                urlProps.setProperty(token.substring(0, pos), token.substring(pos + 1));
-            else
+            }
+            int l_pos = token.indexOf('=');
+            if (l_pos == -1) {
                 urlProps.setProperty(token, "");
+            } else {
+                urlProps.setProperty(token.substring(0, l_pos), URLDecoder.decode(token.substring(l_pos + 1)));
+            }
         }
 
         return urlProps;
@@ -597,86 +599,84 @@ public final class Driver implements java.sql.Driver {
     /**
      * @return the address portion of the URL
      */
-    protected static HostSpec[] hostSpecs(Properties props) {
+    private static HostSpec[] hostSpecs(Properties props) {
         String[] hosts = props.getProperty("PGHOST").split(",");
         String[] ports = props.getProperty("PGPORT").split(",");
         HostSpec[] hostSpecs = new HostSpec[hosts.length];
-        for (int i = 0; i < hostSpecs.length; ++i)
+        for (int i = 0; i < hostSpecs.length; ++i) {
             hostSpecs[i] = new HostSpec(hosts[i], Integer.parseInt(ports[i]));
-
+        }
         return hostSpecs;
     }
 
     /**
      * @return the username of the URL
      */
-    protected static String user(Properties props) {
+    private static String user(Properties props) {
         return props.getProperty("user", "");
     }
 
     /**
      * @return the database name of the URL
      */
-    protected static String database(Properties props) {
+    private static String database(Properties props) {
         return props.getProperty("PGDBNAME", "");
     }
 
     /**
      * @return the timeout from the URL, in milliseconds
      */
-    protected static long timeout(Properties props) {
-        final int msecPerSec = 1000;
-
+    private static long timeout(Properties props) {
         String timeout = PGProperty.LOGIN_TIMEOUT.get(props);
         if (timeout != null) {
             try {
-                return (long) (Float.parseFloat(timeout) * msecPerSec);
+                return (long) (Float.parseFloat(timeout) * 1000);
             } catch (NumberFormatException e) {
                 // Log level isn't set yet, so this doesn't actually
                 // get printed.
-                LOGGER.debug("Couldn't parse loginTimeout value: " + timeout);
+                if (logger.logDebug()) {
+                    logger.debug("Couldn't parse loginTimeout value: " + timeout);
+                }
             }
         }
-        return (long) DriverManager.getLoginTimeout() * msecPerSec;
+        return (long) DriverManager.getLoginTimeout() * 1000;
     }
 
-    /*
-     * This method was added in v6.5, and simply throws an SQLException
-     * for an unimplemented method. I decided to do it this way while
-     * implementing the JDBC2 extensions to JDBC, as it should help keep the
-     * overall driver size down.
-     * It now requires the call Class and the function name to help when the
-     * driver is used with closed software that don't report the stack strace
+    /**
+     * This method was added in v6.5, and simply throws an SQLException for an unimplemented method. I
+     * decided to do it this way while implementing the JDBC2 extensions to JDBC, as it should help
+     * keep the overall driver size down. It now requires the call Class and the function name to help
+     * when the driver is used with closed software that don't report the stack strace
+     *
      * @param callClass the call Class
-     * @param functionName the name of the unimplemented function with the type
-     *  of its arguments
-     * @return PSQLException with a localized message giving the complete
-     *  description of the unimplemeted function
+     * @param functionName the name of the unimplemented function with the type of its arguments
+     * @return PSQLException with a localized message giving the complete description of the
+     *         unimplemeted function
      */
-    public static SQLFeatureNotSupportedException notImplemented(Class callClass, String functionName) {
-        return new SQLFeatureNotSupportedException(GT.tr("Method {0} is not yet implemented.", callClass.getName() + "." + functionName),
+    public static SQLFeatureNotSupportedException notImplemented(Class<?> callClass,
+                                                                 String functionName) {
+        return new SQLFeatureNotSupportedException(
+                GT.tr("Method {0} is not yet implemented.", callClass.getName() + "." + functionName),
                 PSQLState.NOT_IMPLEMENTED.getState());
     }
 
     /**
-     * used to turn logging on to a certain level, can be called
-     * by specifying fully qualified class ie org.postgresql.Driver.setLogLevel()
+     * used to turn logging on to a certain level, can be called by specifying fully qualified class
+     * ie org.postgresql.Driver.setLogLevel()
      *
-     * @param logLevel sets the level which logging will respond to
-     *                 OFF turn off logging
-     *                 INFO being almost no messages
-     *                 DEBUG most verbose
+     * @param logLevel sets the level which logging will respond to OFF turn off logging INFO being
+     *        almost no messages DEBUG most verbose
      */
     public static void setLogLevel(int logLevel) {
         synchronized (Driver.class) {
-            LOGGER.setLogLevel(logLevel);
+            logger.setLogLevel(logLevel);
             logLevelSet = true;
         }
     }
 
     public static int getLogLevel() {
         synchronized (Driver.class) {
-            return LOGGER.getLogLevel();
+            return logger.getLogLevel();
         }
     }
 
@@ -689,33 +689,36 @@ public final class Driver implements java.sql.Driver {
     }
 
     /**
-     * Register the driver against {@link DriverManager}. This is done automatically when the class is loaded.
-     * Dropping the driver from DriverManager's list is possible using {@link #deregister()} method.
+     * Register the driver against {@link DriverManager}. This is done automatically when the class is
+     * loaded. Dropping the driver from DriverManager's list is possible using {@link #deregister()}
+     * method.
      *
      * @throws IllegalStateException if the driver is already registered
-     * @throws SQLException          if registering the driver fails
+     * @throws SQLException if registering the driver fails
      */
     public static void register() throws SQLException {
-        if (isRegistered())
-            throw new IllegalStateException("Driver is already registered. It can only be registered once.");
-
-        Driver driver = new Driver();
-        DriverManager.registerDriver(driver);
-        Driver.registeredDriver = driver;
+        if (isRegistered()) {
+            throw new IllegalStateException(
+                    "Driver is already registered. It can only be registered once.");
+        }
+        Driver registeredDriver = new Driver();
+        DriverManager.registerDriver(registeredDriver);
+        Driver.registeredDriver = registeredDriver;
     }
 
     /**
-     * According to JDBC specification, this driver is registered against {@link DriverManager}
-     * when the class is loaded. To avoid leaks, this method allow unregistering the driver
-     * so that the class can be gc'ed if necessary.
+     * According to JDBC specification, this driver is registered against {@link DriverManager} when
+     * the class is loaded. To avoid leaks, this method allow unregistering the driver so that the
+     * class can be gc'ed if necessary.
      *
      * @throws IllegalStateException if the driver is not registered
-     * @throws SQLException          if deregistering the driver fails
+     * @throws SQLException if deregistering the driver fails
      */
     public static void deregister() throws SQLException {
-        if (!isRegistered())
-            throw new IllegalStateException("Driver is not registered (or it has not been registered using Driver.register() method)");
-
+        if (!isRegistered()) {
+            throw new IllegalStateException(
+                    "Driver is not registered (or it has not been registered using Driver.register() method)");
+        }
         DriverManager.deregisterDriver(registeredDriver);
         registeredDriver = null;
     }
@@ -727,3 +730,4 @@ public final class Driver implements java.sql.Driver {
         return registeredDriver != null;
     }
 }
+

--- a/src/main/java/net/bitnine/agensgraph/graph/Edge.java
+++ b/src/main/java/net/bitnine/agensgraph/graph/Edge.java
@@ -1,0 +1,50 @@
+package net.bitnine.agensgraph.graph;
+
+import org.postgresql.util.GT;
+import org.postgresql.util.PGobject;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.Serializable;
+import java.sql.SQLException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class Edge extends PGobject implements Serializable, Closeable {
+    private static Pattern _pattern;
+    public GID vid;
+    public String label;
+    public String properties;
+
+    {
+        _pattern = Pattern.compile(":(.+)\\[(\\d+):(\\d+)\\](.*)");
+    }
+
+    public Edge() {
+        setType("edge");
+    }
+
+    public void setValue(String s) throws SQLException {
+        Matcher m = _pattern.matcher(s);
+        if (m.find()) {
+            label = m.group(1);
+            vid = new GID(Integer.parseInt(m.group(2)), Integer.parseInt(m.group(3)));
+            properties = m.group(4);
+        }
+        else {
+            throw new PSQLException(GT.tr("Conversion to type {0} failed: {1}.", new Object[]{type, s}),
+                    PSQLState.DATA_TYPE_MISMATCH);
+        }
+    }
+
+    public String getValue() {
+        return "edge ID:" + vid.toString() + ", label:" + label + " properties:" + properties;
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+}

--- a/src/main/java/net/bitnine/agensgraph/graph/GID.java
+++ b/src/main/java/net/bitnine/agensgraph/graph/GID.java
@@ -1,0 +1,22 @@
+package net.bitnine.agensgraph.graph;
+
+public class GID {
+    /**
+     * ID of base object
+     */
+    public int oid;
+
+    /**
+     * ID in the base object
+     */
+    public int id;
+
+    public GID(int oid, int id) {
+        this.oid = oid;
+        this.id = id;
+    }
+
+    public String toString() {
+        return "[" + oid + ":" + id + "]";
+    }
+}

--- a/src/main/java/net/bitnine/agensgraph/graph/Path.java
+++ b/src/main/java/net/bitnine/agensgraph/graph/Path.java
@@ -1,0 +1,19 @@
+package net.bitnine.agensgraph.graph;
+
+import org.postgresql.util.PGobject;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.Serializable;
+
+public class Path extends PGobject implements Serializable, Closeable {
+
+    public Path() {
+        setType("path");
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+}

--- a/src/main/java/net/bitnine/agensgraph/graph/Vertex.java
+++ b/src/main/java/net/bitnine/agensgraph/graph/Vertex.java
@@ -1,0 +1,53 @@
+package net.bitnine.agensgraph.graph;
+
+import org.postgresql.util.GT;
+import org.postgresql.util.PGobject;
+import org.postgresql.util.PSQLException;
+import org.postgresql.util.PSQLState;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.Serializable;
+import java.sql.SQLException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class Vertex extends PGobject implements Serializable, Closeable {
+    private static Pattern _pattern;
+    public GID vid;
+    public String properties;
+
+    {
+        _pattern = Pattern.compile("Node\\[(\\d+):(\\d+)\\](.*)");
+    }
+
+    public Vertex() {
+        setType("vertex");
+    }
+
+    public Vertex(GID vid, String properties) {
+        this.vid = vid;
+        this.properties = properties;
+    }
+
+    public void setValue(String s) throws SQLException {
+        Matcher m = _pattern.matcher(s);
+        if (m.find()) {
+            vid = new GID(Integer.parseInt(m.group(1)), Integer.parseInt(m.group(2)));
+            properties = m.group(3);
+        }
+        else {
+            throw new PSQLException(GT.tr("Conversion to type {0} failed: {1}.", new Object[]{type, s}),
+                    PSQLState.DATA_TYPE_MISMATCH);
+        }
+    }
+
+    public String getValue() {
+        return "vertex ID:" + vid.toString() + ", properties:" + properties;
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+}

--- a/src/test/java/net/bitnine/agensgraph/test/JDBCBasicTest.java
+++ b/src/test/java/net/bitnine/agensgraph/test/JDBCBasicTest.java
@@ -1,0 +1,60 @@
+package net.bitnine.agensgraph.test;
+
+import junit.framework.Assert;
+import junit.framework.TestCase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Properties;
+
+public class JDBCBasicTest extends TestCase {
+
+    private Connection con;
+
+    public void setUp() throws Exception {
+        con = TestUtil.openDB();
+
+        Statement st = con.createStatement();
+        st.execute("create vlabel person");
+        st.execute("create elabel employee");
+    }
+
+    public void tearDown() throws Exception {
+        TestUtil.dropTable(con, "test_a");
+        Statement st = con.createStatement();
+        st.execute("drop vlabel person");
+        st.execute("drop elabel employee");
+
+        TestUtil.closeDB(con);
+    }
+
+    public void test1() throws Exception {
+        System.out.println("test case no. 1");
+        Statement st = con.createStatement();
+        assertNotNull(st);
+
+        st.executeUpdate("insert into graph.person values (1, '{\"name\": \"bitnine\"}')");
+        st.executeUpdate("insert into graph.person values (2, '{\"name\": \"jsyang\"}')");
+        st.executeUpdate("insert into graph.person values (3, '{\"name\": \"someone\"}')");
+        st.executeUpdate("insert into graph.person values (4, '{\"name\": \"tree\"}')");
+
+        st.executeUpdate("insert into graph.employee values (1, 'graph.person'::regclass, 1, 'graph.person'::regclass, 2, '{\"prop\": \"employee\"}')");
+        st.executeUpdate("insert into graph.employee values (2, 'graph.person'::regclass, 2, 'graph.person'::regclass, 3, '{\"prop\": \"manage\"}')");
+        st.executeUpdate("insert into graph.employee values (3, 'graph.person'::regclass, 1, 'graph.person'::regclass, 4, '{\"prop\": \"branch\"}')");
+
+        ResultSet rs = st.executeQuery("MATCH (n)<-[r]-(m), (m)-[s]->(q) RETURN n, r, m, s, q");
+        while (rs.next()) {
+            String n = rs.getObject("n").toString();
+            String r = rs.getObject("r").toString();
+            String m = rs.getObject("m").toString();
+            String s = rs.getObject("s").toString();
+            String q = rs.getObject("q").toString();
+            System.out.println("row: " + n + ", " + r + ", " + m + ", " + s + ", " + q);
+        }
+    }
+
+}

--- a/src/test/java/net/bitnine/agensgraph/test/TestUtil.java
+++ b/src/test/java/net/bitnine/agensgraph/test/TestUtil.java
@@ -1,0 +1,675 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2004-2014, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+
+package net.bitnine.agensgraph.test;
+
+import org.postgresql.PGProperty;
+import org.postgresql.core.ServerVersion;
+import org.postgresql.core.Version;
+import org.postgresql.jdbc.PgConnection;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.sql.*;
+import java.util.Properties;
+
+/**
+ * Utility class for JDBC tests
+ */
+public class TestUtil {
+  /*
+   * Returns the Test database JDBC URL
+   */
+  public static String getURL() {
+    return getURL(getServer(), getPort());
+  }
+
+  public static String getURL(String server, int port) {
+    String protocolVersion = "";
+    if (getProtocolVersion() != 0) {
+      protocolVersion = "&protocolVersion=" + getProtocolVersion();
+    }
+
+    String binaryTransfer = "";
+    if (getBinaryTransfer() != null && !getBinaryTransfer().equals("")) {
+      binaryTransfer = "&binaryTransfer=" + getBinaryTransfer();
+    }
+
+    String receiveBufferSize = "";
+    if (getReceiveBufferSize() != -1) {
+      receiveBufferSize = "&receiveBufferSize=" + getReceiveBufferSize();
+    }
+
+    String sendBufferSize = "";
+    if (getSendBufferSize() != -1) {
+      sendBufferSize = "&sendBufferSize=" + getSendBufferSize();
+    }
+
+    String ssl = "";
+    if (getSSL() != null) {
+      ssl = "&ssl=" + getSSL();
+    }
+
+    return "jdbc:agensgraph://"
+        + server + ":"
+        + port + "/"
+        + getDatabase()
+        + "?loglevel=" + getLogLevel()
+        + protocolVersion
+        + binaryTransfer
+        + receiveBufferSize
+        + sendBufferSize
+        + ssl;
+  }
+
+  /*
+   * Returns the Test server
+   */
+  public static String getServer() {
+    return System.getProperty("server", "localhost");
+  }
+
+  /*
+   * Returns the Test port
+   */
+  public static int getPort() {
+    return Integer.parseInt(System.getProperty("port", System.getProperty("def_pgport")));
+  }
+
+  /*
+   * Returns the server side prepared statement threshold.
+   */
+  public static int getPrepareThreshold() {
+    return Integer.parseInt(System.getProperty("preparethreshold", "5"));
+  }
+
+  public static int getProtocolVersion() {
+    return Integer.parseInt(System.getProperty("protocolVersion", "0"));
+  }
+
+  /*
+   * Returns the Test database
+   */
+  public static String getDatabase() {
+    return System.getProperty("database");
+  }
+
+  /*
+   * Returns the Postgresql username
+   */
+  public static String getUser() {
+    return System.getProperty("username");
+  }
+
+  /*
+   * Returns the user's password
+   */
+  public static String getPassword() {
+    return System.getProperty("password");
+  }
+
+  /*
+   * Returns the user for SSPI authentication tests
+   */
+  public static String getSSPIUser() {
+    return System.getProperty("sspiusername");
+  }
+
+  /*
+   * postgres like user
+   */
+  public static String getPrivilegedUser() {
+    return System.getProperty("privilegedUser");
+  }
+
+  public static String getPrivilegedPassword() {
+    return System.getProperty("privilegedPassword");
+  }
+
+  /*
+   * Returns the log level to use
+   */
+  public static int getLogLevel() {
+    return Integer.parseInt(System.getProperty("loglevel", "0"));
+  }
+
+  /*
+   * Returns the binary transfer mode to use
+   */
+  public static String getBinaryTransfer() {
+    return System.getProperty("binaryTransfer");
+  }
+
+  public static int getSendBufferSize() {
+    return Integer.parseInt(System.getProperty("sendBufferSize", "-1"));
+  }
+
+  public static int getReceiveBufferSize() {
+    return Integer.parseInt(System.getProperty("receiveBufferSize", "-1"));
+  }
+
+  public static String getSSL() {
+    return System.getProperty("ssl");
+  }
+
+  static {
+    try {
+      initDriver();
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new RuntimeException("Unable to initialize driver", e);
+    }
+  }
+
+  private static boolean initialized = false;
+
+  public static Properties loadPropertyFiles(String... names) {
+    Properties p = new Properties();
+    for (String name : names) {
+      for (int i = 0; i < 2; i++) {
+        // load x.properties, then x.local.properties
+        if (i == 1 && name.endsWith(".properties") && !name.endsWith(".local.properties")) {
+          name = name.replaceAll("\\.properties$", ".local.properties");
+        }
+        File f = getFile(name);
+        if (!f.exists()) {
+          System.out.println("Configuration file " + f.getAbsolutePath()
+              + " does not exist. Consider adding it to specify test db host and login");
+          continue;
+        }
+        try {
+          p.load(new FileInputStream(f));
+        } catch (IOException ex) {
+          // ignore
+        }
+      }
+    }
+    return p;
+  }
+
+  public static void initDriver() throws Exception {
+    synchronized (TestUtil.class) {
+      if (initialized) {
+        return;
+      }
+
+      Properties p = loadPropertyFiles("build.properties");
+      p.putAll(System.getProperties());
+      System.getProperties().putAll(p);
+
+      if (getLogLevel() > 0) {
+        // Ant's junit task likes to buffer stdout/stderr and tends to run out of memory.
+        // So we put debugging output to a file instead.
+        java.io.Writer output = new java.io.FileWriter("postgresql-jdbc-tests.debug.txt", true);
+        DriverManager.setLogWriter(new java.io.PrintWriter(output, true));
+      }
+
+      net.bitnine.agensgraph.Driver.setLogLevel(getLogLevel()); // Also loads and registers driver.
+      initialized = true;
+    }
+  }
+
+  /**
+   * Resolves file path with account of {@code build.properties.relative.path}. This is a bit tricky
+   * since during maven release, maven does a temporary checkout to {@code core/target/checkout}
+   * folder, so that script should somehow get {@code build.local.properties}
+   *
+   * @param name original name of the file, as if it was in the root pgjdbc folder
+   * @return actual location of the file
+   */
+  public static File getFile(String name) {
+    if (name == null) {
+      throw new IllegalArgumentException("null file name is not expected");
+    }
+    if (name.startsWith("/")) {
+      return new File(name);
+    }
+    return new File(System.getProperty("build.properties.relative.path", "./"), name);
+  }
+
+  /**
+   * Get a connection using a priviliged user mostly for tests that the ability to load C functions
+   * now as of 4/14
+   *
+   * @return connection using a priviliged user mostly for tests that the ability to load C
+   *         functions now as of 4/14
+   */
+  public static Connection openPrivilegedDB() throws Exception {
+
+    initDriver();
+    Properties properties = new Properties();
+    properties.setProperty("user", getPrivilegedUser());
+    properties.setProperty("password", getPrivilegedPassword());
+    return DriverManager.getConnection(getURL(), properties);
+
+  }
+
+  /**
+   * Helper - opens a connection.
+   *
+   * @return connection
+   */
+  public static Connection openDB() throws Exception {
+    return openDB(new Properties());
+  }
+
+  /*
+   * Helper - opens a connection with the allowance for passing additional parameters, like
+   * "compatible".
+   */
+  public static Connection openDB(Properties props) throws Exception {
+    initDriver();
+
+    // Allow properties to override the user name.
+    String user = props.getProperty("username");
+    if (user == null) {
+      user = getUser();
+    }
+    if (user == null) {
+      throw new IllegalArgumentException(
+          "user name is not specified. Please specify 'username' property via -D or build.properties");
+    }
+    props.setProperty("user", user);
+    String password = getPassword();
+    if (password == null) {
+      password = "";
+    }
+    props.setProperty("password", password);
+    if (!props.containsKey(PGProperty.PREPARE_THRESHOLD.getName())) {
+      PGProperty.PREPARE_THRESHOLD.set(props, getPrepareThreshold());
+    }
+
+    return DriverManager.getConnection(getURL(), props);
+  }
+
+  /*
+   * Helper - closes an open connection.
+   */
+  public static void closeDB(Connection con) throws SQLException {
+    if (con != null) {
+      con.close();
+    }
+  }
+
+  /*
+   * Helper - creates a test schema for use by a test
+   */
+  public static void createSchema(Connection con, String schema) throws SQLException {
+    Statement st = con.createStatement();
+    try {
+      // Drop the schema
+      dropSchema(con, schema);
+
+      // Now create the schema
+      String sql = "CREATE SCHEMA " + schema;
+
+      st.executeUpdate(sql);
+    } finally {
+      st.close();
+    }
+  }
+
+  /*
+   * Helper - drops a schema
+   */
+  public static void dropSchema(Connection con, String schema) throws SQLException {
+    Statement stmt = con.createStatement();
+    try {
+      String sql = "DROP SCHEMA " + schema;
+      if (haveMinimumServerVersion(con, ServerVersion.v7_3)) {
+        sql += " CASCADE ";
+      }
+      stmt.executeUpdate(sql);
+    } catch (SQLException ex) {
+      // Since every create schema issues a drop schema
+      // it's easy to get a schema doesn't exist error.
+      // we want to ignore these, but if we're in a
+      // transaction then we've got trouble
+      if (!con.getAutoCommit()) {
+        throw ex;
+      }
+    }
+  }
+
+  /*
+   * Helper - creates a test table for use by a test
+   */
+  public static void createTable(Connection con, String table, String columns) throws SQLException {
+    // by default we don't request oids.
+    createTable(con, table, columns, false);
+  }
+
+  /*
+   * Helper - creates a test table for use by a test
+   */
+  public static void createTable(Connection con, String table, String columns, boolean withOids)
+      throws SQLException {
+    Statement st = con.createStatement();
+    try {
+      // Drop the table
+      dropTable(con, table);
+
+      // Now create the table
+      String sql = "CREATE TABLE " + table + " (" + columns + ") ";
+
+      // Starting with 8.0 oids may be turned off by default.
+      // Some tests need them, so they flag that here.
+      if (withOids && haveMinimumServerVersion(con, ServerVersion.v8_0)) {
+        sql += " WITH OIDS";
+      }
+      st.executeUpdate(sql);
+    } finally {
+      st.close();
+    }
+  }
+
+  /**
+   * Helper creates a temporary table
+   *
+   * @param con Connection
+   * @param table String
+   * @param columns String
+   */
+
+  public static void createTempTable(Connection con, String table, String columns)
+      throws SQLException {
+    Statement st = con.createStatement();
+    try {
+      // Drop the table
+      dropTable(con, table);
+
+      // Now create the table
+      st.executeUpdate("create temp table " + table + " (" + columns + ")");
+    } finally {
+      st.close();
+    }
+  }
+
+  /**
+   * Helper creates an enum type
+   *
+   * @param con Connection
+   * @param name String
+   * @param values String
+   */
+
+  public static void createEnumType(Connection con, String name, String values)
+      throws SQLException {
+    Statement st = con.createStatement();
+    try {
+      dropType(con, name);
+
+
+      // Now create the table
+      st.executeUpdate("create type " + name + " as enum (" + values + ")");
+    } finally {
+      st.close();
+    }
+  }
+
+  /**
+   * Helper creates an composite type
+   *
+   * @param con Connection
+   * @param name String
+   * @param values String
+   */
+
+  public static void createCompositeType(Connection con, String name, String values)
+      throws SQLException {
+    Statement st = con.createStatement();
+    try {
+      dropType(con, name);
+
+
+      // Now create the table
+      st.executeUpdate("create type " + name + " as (" + values + ")");
+    } finally {
+      st.close();
+    }
+  }
+
+  /*
+   * drop a sequence because older versions don't have dependency information for serials
+   */
+  public static void dropSequence(Connection con, String sequence) throws SQLException {
+    Statement stmt = con.createStatement();
+    try {
+      String sql = "DROP SEQUENCE " + sequence;
+      stmt.executeUpdate(sql);
+    } catch (SQLException sqle) {
+      if (!con.getAutoCommit()) {
+        throw sqle;
+      }
+    }
+  }
+
+  /*
+   * Helper - drops a table
+   */
+  public static void dropTable(Connection con, String table) throws SQLException {
+    Statement stmt = con.createStatement();
+    try {
+      String sql = "DROP TABLE " + table;
+      if (haveMinimumServerVersion(con, ServerVersion.v7_3)) {
+        sql += " CASCADE ";
+      }
+      stmt.executeUpdate(sql);
+    } catch (SQLException ex) {
+      // Since every create table issues a drop table
+      // it's easy to get a table doesn't exist error.
+      // we want to ignore these, but if we're in a
+      // transaction then we've got trouble
+      if (!con.getAutoCommit()) {
+        throw ex;
+      }
+    }
+  }
+
+  /*
+   * Helper - drops a type
+   */
+  public static void dropType(Connection con, String type) throws SQLException {
+    Statement stmt = con.createStatement();
+    try {
+      String sql = "DROP TYPE " + type;
+      stmt.executeUpdate(sql);
+    } catch (SQLException ex) {
+      if (!con.getAutoCommit()) {
+        throw ex;
+      }
+    }
+  }
+
+  /*
+   * Helper - generates INSERT SQL - very simple
+   */
+  public static String insertSQL(String table, String values) {
+    return insertSQL(table, null, values);
+  }
+
+  public static String insertSQL(String table, String columns, String values) {
+    String s = "INSERT INTO " + table;
+
+    if (columns != null) {
+      s = s + " (" + columns + ")";
+    }
+
+    return s + " VALUES (" + values + ")";
+  }
+
+  /*
+   * Helper - generates SELECT SQL - very simple
+   */
+  public static String selectSQL(String table, String columns) {
+    return selectSQL(table, columns, null, null);
+  }
+
+  public static String selectSQL(String table, String columns, String where) {
+    return selectSQL(table, columns, where, null);
+  }
+
+  public static String selectSQL(String table, String columns, String where, String other) {
+    String s = "SELECT " + columns + " FROM " + table;
+
+    if (where != null) {
+      s = s + " WHERE " + where;
+    }
+    if (other != null) {
+      s = s + " " + other;
+    }
+
+    return s;
+  }
+
+  /*
+   * Helper to prefix a number with leading zeros - ugly but it works...
+   *
+   * @param v value to prefix
+   *
+   * @param l number of digits (0-10)
+   */
+  public static String fix(int v, int l) {
+    String s = "0000000000".substring(0, l) + Integer.toString(v);
+    return s.substring(s.length() - l);
+  }
+
+  public static String escapeString(Connection con, String value) throws SQLException {
+    if (con instanceof PgConnection) {
+      return ((PgConnection) con).escapeString(value);
+    }
+    return value;
+  }
+
+  public static boolean getStandardConformingStrings(Connection con) {
+    if (con instanceof PgConnection) {
+      return ((PgConnection) con).getStandardConformingStrings();
+    }
+    return false;
+  }
+
+  /**
+   * Determine if the given connection is connected to a server with a version of at least the given
+   * version. This is convenient because we are working with a java.sql.Connection, not an Postgres
+   * connection.
+   */
+  public static boolean haveMinimumServerVersion(Connection con, String version)
+      throws SQLException {
+    if (con instanceof PgConnection) {
+      return ((PgConnection) con).haveMinimumServerVersion(version);
+    }
+    return false;
+  }
+
+  public static boolean haveMinimumServerVersion(Connection con, int version) throws SQLException {
+    if (con instanceof PgConnection) {
+      return ((PgConnection) con).haveMinimumServerVersion(version);
+    }
+    return false;
+  }
+
+  public static boolean haveMinimumServerVersion(Connection con, Version version)
+      throws SQLException {
+    if (con instanceof PgConnection) {
+      return ((PgConnection) con).haveMinimumServerVersion(version);
+    }
+    return false;
+  }
+
+  public static boolean haveMinimumJVMVersion(String version) {
+    String jvm = System.getProperty("java.version");
+    return (jvm.compareTo(version) >= 0);
+  }
+
+  public static boolean isProtocolVersion(Connection con, int version) {
+    if (con instanceof PgConnection) {
+      return (version == ((PgConnection) con).getProtocolVersion());
+
+    }
+    return false;
+  }
+
+  /**
+   * Print a ResultSet to System.out. This is useful for debugging tests.
+   */
+  public static void printResultSet(ResultSet rs) throws SQLException {
+    ResultSetMetaData rsmd = rs.getMetaData();
+    for (int i = 1; i <= rsmd.getColumnCount(); i++) {
+      if (i != 1) {
+        System.out.print(", ");
+      }
+      System.out.print(rsmd.getColumnName(i));
+    }
+    System.out.println();
+    while (rs.next()) {
+      for (int i = 1; i <= rsmd.getColumnCount(); i++) {
+        if (i != 1) {
+          System.out.print(", ");
+        }
+        System.out.print(rs.getString(i));
+      }
+      System.out.println();
+    }
+  }
+
+  /*
+   * Find the column for the given label. Only SQLExceptions for system or set-up problems are
+   * thrown. The PSQLState.UNDEFINED_COLUMN type exception is consumed to allow cleanup. Relying on
+   * the caller to detect if the column lookup was successful.
+   */
+  public static int findColumn(PreparedStatement query, String label) throws SQLException {
+    int returnValue = 0;
+    ResultSet rs = query.executeQuery();
+    if (rs.next()) {
+      try {
+        returnValue = rs.findColumn(label);
+      } catch (SQLException sqle) {
+      } // consume exception to allow cleanup of resource.
+    }
+    rs.close();
+    return returnValue;
+  }
+
+  /**
+   * Close a Connection and ignore any errors during closing.
+   */
+  public static void closeQuietly(Connection conn) {
+    if (conn != null) {
+      try {
+        conn.close();
+      } catch (SQLException ignore) {
+      }
+    }
+  }
+
+  /**
+   * Close a Statement and ignore any errors during closing.
+   */
+  public static void closeQuietly(Statement stmt) {
+    if (stmt != null) {
+      try {
+        stmt.close();
+      } catch (SQLException ignore) {
+      }
+    }
+  }
+
+  /**
+   * Close a ResultSet and ignore any errors during closing.
+   */
+  public static void closeQuietly(ResultSet rs) {
+    if (rs != null) {
+      try {
+        rs.close();
+      } catch (SQLException ignore) {
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add vertex, edge and path datatype in JDBC driver.
Postgres JDBC driver is updated to postgresql-9.4.1208.jre7.jar.
There're some changes in this driver,
so Driver class in net.bitnine.agensgraph is also changed.
The newly added datatypes are included in the typecache
using connection string properties (see Driver.java)
The string representation of these types are not fixed yet.
But this commit implements according to current string representations.